### PR TITLE
Added support for GitHub Updater

### DIFF
--- a/acf-child-post-field.php
+++ b/acf-child-post-field.php
@@ -13,6 +13,8 @@
  * Text Domain: acf_child_post
  * Domain Path: /i18n/languages/
  *
+ * GitHub Plugin URI: lucasstark/acf-child-post-field
+ *
  * @package ACF_Child_Post_Field
  * @category Core
  * @author Lucas Stark


### PR DESCRIPTION
The GitHub Updater plugin works with the "release" system and picks up new versions automatically. It can also detect when new releases are added on GitHub and can update them using WordPress own core API.

See: 
https://github.com/afragen/github-updater
