### PR TITLE
Fixed title saving

### DIFF
--- a/acf-child-post-field-v5.php
+++ b/acf-child-post-field-v5.php
@@ -444,7 +444,8 @@ class ACF_Child_Post_Field_V5 extends acf_field {
 												    'label' => 'Title',
 												    'type' => 'text',
 												    'value' => $post->post_title,
-												    'key' => 'acf-child-post-field-post-title',
+												    // Removed key as it broke the title
+												    //'key' => 'acf-child-post-field-post-title',
 												    'required' => true
 													) ), $el );
 											}

--- a/assets/js/acf-child-post-field.js
+++ b/assets/js/acf-child-post-field.js
@@ -36,7 +36,7 @@
 				self.remove( $(this).closest('div.acf-field-object') );
 			});
 			
-			this.$field.on('keyup', 'div[data-key="acf-child-post-field-post-title"] input', function( e ){
+			this.$field.on('keyup', 'div input[name$="[post_title]"]', function( e ){
 				
 				self.update_child_title_label( $(this) );
 				


### PR DESCRIPTION
Saving titles was not working and resulted in creating posts with no titles. This fix should resolve this bug.