### PR TITLE
Fixed bugs / mishandling of redundant child rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Forked from https://github.com/lucasstark/acf-child-post-field
 
 Code had multiple errors at the point where I forked it - I've gone some way to fixing these and the plugin is now stable **for my required use**. You may still find bugs that are critical. See my commits for more info and the [original repo](https://github.com/lucasstark/acf-child-post-field) for info on what the plugin does. 
 
-*"Any time you would normally use a post object field or a post relation field you can use this instead.  It will allow you to directly edit the "child" posts from it's parent."*
+*"Any time you would normally use a post object field or a post relation field you can use this instead.  It will allow you to directly edit the 'child' posts from its parent."*

--- a/README.md
+++ b/README.md
@@ -1,30 +1,7 @@
 # acf-child-post-field
-Adds the ability to edit related posts directly from a parent post. 
 
-Contributors: lucasstark
+Forked from https://github.com/lucasstark/acf-child-post-field
 
-Requires at least: 4.0
+Code had multiple errors at the point where I forked it - I've gone some way to fixing these and the plugin is now stable **for my required use**. You may still find bugs that are critical. See my commits for more info and the [original repo](https://github.com/lucasstark/acf-child-post-field) for info on what the plugin does. 
 
-Tested up to: 4.8.1
-
-Stable tag: 1.0.0
-
-License: GPLv3
-
-License URI: http://www.gnu.org/licenses/gpl-3.0.html
-
-
-Child Post Field is a field similar to the Post Object field, however it allows you to actually edit a selected post directly from the parent post referencing it.  This is very useful when you are using custom post types which are logically hierarchical in nature.  
-
-Examples of use case might include:
-House -> Rooms
-
-Degree Programs -> Courses
-
-Teams -> Team Members
-
-Products -> Product Variations
-
-Workshop -> Speakers
-
-Any time you would normally use a post object field or a post relation field you can use this instead.  It will allow you to directly edit the "child" posts from it's parent. 
+*"Any time you would normally use a post object field or a post relation field you can use this instead.  It will allow you to directly edit the "child" posts from it's parent."*

--- a/acf-child-post-field-v5.php
+++ b/acf-child-post-field-v5.php
@@ -790,8 +790,8 @@ class ACF_Child_Post_Field_V5 extends acf_field {
 		// Rows removed from the repeater field
 		$redundant_rows = is_array($value) ? array_diff_key( $db_value, $value ) : array();
 
-		// If $value is empty but db isn't, consolidate db
-		if( count($redundant_rows) == 0 && count($db_value) > 0 ) {
+		// If there's no data to update but there's data still in the db, consolidate 
+		if( !is_array($value) && count($db_value) > 0 ) {
 			$redundant_rows = $db_value;
 		}
 		

--- a/acf-child-post-field-v5.php
+++ b/acf-child-post-field-v5.php
@@ -788,7 +788,12 @@ class ACF_Child_Post_Field_V5 extends acf_field {
 		$db_value = acf_get_value( $post_id, $field );
 
 		// Rows removed from the repeater field
-		$redundant_rows = array_diff_key( $db_value, $value );
+		$redundant_rows = is_array($value) ? array_diff_key( $db_value, $value ) : array();
+
+		// If $value is empty but db isn't, consolidate db
+		if( count($redundant_rows) == 0 && count($db_value) > 0 ) {
+			$redundant_rows = $db_value;
+		}
 		
 		// Do nothing for autosaves and revisions
 		$post = get_post( $post_id );

--- a/acf-child-post-field-v5.php
+++ b/acf-child-post-field-v5.php
@@ -806,6 +806,17 @@ class ACF_Child_Post_Field_V5 extends acf_field {
 			unset( $value['acfcloneindex'] );
 		}
 
+		/**
+		 * TODO: Redundant meta data still gets left in db when we delete 
+		 * a repeater row where there are subsequent rows left in place 
+		 * after it. It would be better to simply compare what's in the db
+		 * with what's in the $value array or purge all meta data prior to 
+		 * updating.
+		 * 
+		 * This appears to be non-critical / non-breaking at present but 
+		 * could be a gotcha for custom SQL queries.
+		 */
+
 		// Act on redundant rows 
 		if( count($redundant_rows) > 0 ) {
 

--- a/acf-child-post-field-v5.php
+++ b/acf-child-post-field-v5.php
@@ -320,21 +320,30 @@ class ACF_Child_Post_Field_V5 extends acf_field {
 		    'name' => $field['name'],
 		) );
 		?>
-		<div id="acf-child-post-field-posts" <?php acf_esc_attr_e( array('class' => 'acf-childbuilder', 'data-min' => $field['min'], 'data-max' => $field['max']) ); ?>>
+<div id="acf-child-post-field-posts" <?php acf_esc_attr_e( array('class'=> 'acf-childbuilder', 'data-min' =>
+  $field['min'], 'data-max' => $field['max']) ); ?>>
 
-			<div class="acf-field-list-wrap">
-				<ul class="acf-hl acf-thead">
-					<li class="li-field-order"><?php _e( 'Order', 'acf_child_post_field' ); ?></li>
-					<li class="li-field-label"><?php _e( 'Title', 'acf_child_post_field' ); ?></li>
-					<li class="li-field-name"><?php _e( 'Created', 'acf_child_post_field' ); ?></li>
-					<li class="li-field-type"><?php _e( 'Author' ); ?></li>
-				</ul>
+  <div class="acf-field-list-wrap">
+    <ul class="acf-hl acf-thead">
+      <li class="li-field-order">
+        <?php _e( 'Order', 'acf_child_post_field' ); ?>
+      </li>
+      <li class="li-field-label">
+        <?php _e( 'Title', 'acf_child_post_field' ); ?>
+      </li>
+      <li class="li-field-name">
+        <?php _e( 'Created', 'acf_child_post_field' ); ?>
+      </li>
+      <li class="li-field-type">
+        <?php _e( 'Author' ); ?>
+      </li>
+    </ul>
 
-				<div class="acf-field-list">
+    <div class="acf-field-list">
 
-					<?php foreach ( $field['value'] as $i => $row ): ?>
-						<?php $clone_class = ($i === 'acfcloneindex') ? ' acf-clone' : ''; ?>
-						<?php
+      <?php foreach ( $field['value'] as $i => $row ): ?>
+      <?php $clone_class = ($i === 'acfcloneindex') ? ' acf-clone' : ''; ?>
+      <?php
 						// prevent childbuilder field from creating multiple conditional logic items for each row
 						$sub_field = $field['acf_child_field'];
 						if ( $i !== 'acfcloneindex' ) {
@@ -372,30 +381,39 @@ class ACF_Child_Post_Field_V5 extends acf_field {
 							$post->post_date = '0000-00-00 00:00:00';
 						}
 						?>
-						<div class="acf-field-object <?php echo $clone_class; ?>">
+      <div class="acf-field-object <?php echo $clone_class; ?>">
 
-							<div class="meta">
+        <div class="meta">
 
-							</div>
+        </div>
 
-							<div class="handle">
-								<ul class="acf-hl acf-tbody">
-									<li class="li-field-order">
-										<span class="acf-icon large"><?php echo $i; ?></span>
-									</li>
-									<li class="li-field-label">
-										<strong>
-											<a class="edit-field" title="<?php _e( 'Edit', 'acf_child_post_field' ); ?> <?php echo esc_attr( $field['child_label'] ); ?>" href="#"><?php echo $post->post_title; ?></a>
-										</strong>
-										<div class="row-options">
-											<a class="edit-field" title="<?php _e( 'Edit', 'acf_child_post_field' ); ?> <?php echo esc_attr( $field['child_label'] ); ?>" href="#"><?php _e( 'Edit', 'acf_child_post_field' ); ?></a>
-											<a class="duplicate-field" title="<?php _e( 'Duplicate', 'acf_child_post_field' ); ?> <?php echo esc_attr( $field['child_label'] ); ?>" href="#"><?php _e( 'Duplicate', 'acf_child_post_field' ); ?></a>
-											<a class="delete-field" title="<?php _e( 'Delete', 'acf_child_post_field' ); ?> <?php echo esc_attr( $field['child_label'] ); ?>" href="#"><?php _e( 'Delete', 'acf_child_post_field' ); ?></a>
-										</div>
-									</li>
-									<li class="li-field-name">
+        <div class="handle">
+          <ul class="acf-hl acf-tbody">
+            <li class="li-field-order">
+              <span class="acf-icon large">
+                <?php echo $i; ?></span>
+            </li>
+            <li class="li-field-label">
+              <strong>
+                <a class="edit-field" title="<?php _e( 'Edit', 'acf_child_post_field' ); ?> <?php echo esc_attr( $field['child_label'] ); ?>"
+                  href="#">
+                  <?php echo $post->post_title; ?></a>
+              </strong>
+              <div class="row-options">
+                <a class="edit-field" title="<?php _e( 'Edit', 'acf_child_post_field' ); ?> <?php echo esc_attr( $field['child_label'] ); ?>"
+                  href="#">
+                  <?php _e( 'Edit', 'acf_child_post_field' ); ?></a>
+                <a class="duplicate-field" title="<?php _e( 'Duplicate', 'acf_child_post_field' ); ?> <?php echo esc_attr( $field['child_label'] ); ?>"
+                  href="#">
+                  <?php _e( 'Duplicate', 'acf_child_post_field' ); ?></a>
+                <a class="delete-field" title="<?php _e( 'Delete', 'acf_child_post_field' ); ?> <?php echo esc_attr( $field['child_label'] ); ?>"
+                  href="#">
+                  <?php _e( 'Delete', 'acf_child_post_field' ); ?></a>
+              </div>
+            </li>
+            <li class="li-field-name">
 
-										<?php
+              <?php
 										if ( '0000-00-00 00:00:00' == $post->post_date ) {
 											$t_time = $h_time = __( 'Unpublished' );
 											$time_diff = 0;
@@ -416,24 +434,25 @@ class ACF_Child_Post_Field_V5 extends acf_field {
 										?>
 
 
-									</li>
-									<li class="li-field-type"><?php printf( '<a href="%s">%s</a>', esc_url( add_query_arg( array('post_type' => $post->post_type, 'author' => get_the_author_meta( 'ID', $post->post_author )), 'edit.php' ) ), get_the_author_meta( 'display_name', $post->post_author ) ); ?>
-									</li>	
-								</ul>
-							</div>
+            </li>
+            <li class="li-field-type">
+              <?php printf( '<a href="%s">%s</a>', esc_url( add_query_arg( array('post_type' => $post->post_type, 'author' => get_the_author_meta( 'ID', $post->post_author )), 'edit.php' ) ), get_the_author_meta( 'display_name', $post->post_author ) ); ?>
+            </li>
+          </ul>
+        </div>
 
-							<div class="settings">
-								<table <?php acf_esc_attr_e( array('class' => "acf-table acf-input-table {$field['layout']}-layout") ); ?>>
-									<tbody>
-										<tr class="acf-row">
+        <div class="settings">
+          <table <?php acf_esc_attr_e( array('class'=> "acf-table acf-input-table {$field['layout']}-layout") ); ?>>
+            <tbody>
+              <tr class="acf-row">
 
-											<?php if ( $show_order ): ?>
-												<td class="order"></td>
-											<?php endif; ?>
+                <?php if ( $show_order ): ?>
+                <td class="order"></td>
+                <?php endif; ?>
 
-											<?php echo $before_fields; ?>
-													
-											<?php
+                <?php echo $before_fields; ?>
+
+                <?php
 											// render input
 											acf_render_field_wrap( $sub_field, $el );
 
@@ -507,35 +526,38 @@ class ACF_Child_Post_Field_V5 extends acf_field {
 												acf_render_field_wrap( $child_field, $el );
 												?>
 
-											<?php endforeach; ?>
+                <?php endforeach; ?>
 
-											<?php echo $after_fields; ?>
-
-
-											<td class="remove">
-											</td>
+                <?php echo $after_fields; ?>
 
 
-										</tr>
-
-									</tbody>
-								</table>
-							</div>
-						</div>
-					<?php endforeach; ?>
-				</div>
+                <td class="remove">
+                </td>
 
 
-				<ul class="acf-hl acf-tfoot">
-					<li class="comic-sans"><i class="acf-sprite-arrow"></i><?php _e( 'Drag and drop to reorder', 'acf' ); ?></li>
-					<li class="acf-fr">
-						<a href="#" class="acf-button blue acf-childbuilder-add-row">+ <?php echo $field['button_label']; ?></a>
-					</li>
-				</ul>
-			</div>
+              </tr>
 
-		</div>
-		<?php
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <?php endforeach; ?>
+    </div>
+
+
+    <ul class="acf-hl acf-tfoot">
+      <li class="comic-sans"><i class="acf-sprite-arrow"></i>
+        <?php _e( 'Drag and drop to reorder', 'acf' ); ?>
+      </li>
+      <li class="acf-fr">
+        <a href="#" class="acf-button blue acf-childbuilder-add-row">+
+          <?php echo $field['button_label']; ?></a>
+      </li>
+    </ul>
+  </div>
+
+</div>
+<?php
 	}
 
 	function input_admin_enqueue_scripts() {
@@ -762,60 +784,31 @@ class ACF_Child_Post_Field_V5 extends acf_field {
 
 	function update_value( $value, $post_id, $field ) {
 
+		// The value currently stored (hasn't been overwritten yet)
+		$db_value = acf_get_value( $post_id, $field );
+
+		// Rows removed from the repeater field
+		$redundant_rows = array_diff_key( $db_value, $value );
+		
+		// Do nothing for autosaves and revisions
 		$post = get_post( $post_id );
 		if ( wp_is_post_autosave( $post ) || wp_is_post_revision( $post ) ) {
 			return $value;
 		}
 
-		// remove acfcloneindex
+		// Remove acfcloneindex
 		if ( isset( $value['acfcloneindex'] ) ) {
 			unset( $value['acfcloneindex'] );
 		}
 
+		// Act on redundant rows 
+		if( count($redundant_rows) > 0 ) {
 
-		// vars
-		$total = 0;
+			foreach( $redundant_rows as $index => $row ) {
 
+				$key = "{$field['name']}_{$index}{$field['acf_child_field']['name']}";
 
-		// update sub fields
-		if ( !empty( $value ) ) {
-
-			// $i
-			$i = -1;
-
-
-			// loop through rows
-			foreach ( $value as $row ) {
-				// $i
-				$i++;
-				$sub_field = $field['acf_child_field'];
-				$sub_field['name'] = "{$field['name']}_{$i}_acf_child_field_post_id";
-
-				
-				// increase total
-				
-				$child_post_id = $this->update_child_value($post_id, $row, $field, $i);
-				if ( !empty($child_post_id) ) {
-					$total++;
-					acf_update_value( $child_post_id, $post_id, $sub_field );
-				}
-
-
-				// if
-			}
-			// foreach
-		}
-
-
-		// if
-		// get old value (db only)
-		$old_total = intval( acf_get_value( $post_id, $field, true ) );
-
-		if ( $old_total > $total ) {
-
-			for ( $i = $total; $i < $old_total; $i++ ) {
-
-				$key = "{$field['name']}_{$i}{$field['acf_child_field']['name']}";
+				// Check a value exists in the db
 				$child_to_remove = get_post_meta( $post_id, $key, true );
 
 				if ( !empty( $child_to_remove ) ) {
@@ -835,16 +828,43 @@ class ACF_Child_Post_Field_V5 extends acf_field {
 					}
 				}
 
-				acf_delete_value( $post_id, $key );
+				// Delete redundant meta data
+				acf_delete_metadata( $post_id, $key );
+				acf_delete_metadata( $post_id, $key, true );
+				
 			}
-			// for
+
 		}
 
-		// if
-		// update $value and return to allow for the normal save function to run
+		// Tally children
+		$total = 0;
+
+		// Update sub fields
+		if ( !empty( $value ) ) {
+
+			$i = -1;
+
+			// Loop through rows
+			foreach ( $value as $row ) {
+
+				$i++;
+				$sub_field = $field['acf_child_field'];
+				$sub_field['name'] = "{$field['name']}_{$i}_acf_child_field_post_id";
+
+				// Increase total
+				$child_post_id = $this->update_child_value($post_id, $row, $field, $i);
+				if ( !empty($child_post_id) ) {
+					$total++;
+					acf_update_value( $child_post_id, $post_id, $sub_field );
+				}
+
+			}
+
+		}
+
+		// Update $value and return to allow for the normal save function to run
 		$value = $total;
 
-		// return
 		return $value;
 	}
 

--- a/assets/js/acf-child-post-field.js
+++ b/assets/js/acf-child-post-field.js
@@ -1,50 +1,44 @@
-(function ($) {
+;(function($) {
+  acf.fields.childbuilderbuilder = acf.field.extend({
+    type: "childbuilder",
+    $el: null,
+    $input: null,
+    $field_list: null,
+    $clone: null,
+    actions: {
+      ready: "initialize",
+      append: "initialize",
+      show: "show"
+    },
+    events: {
+      "click .acf-childbuilder-add-row": "add",
+      "click .acf-childbuilder-remove-row": "remove"
+    },
+    focus: function() {
+      this.$el = this.$field.find(".acf-childbuilder:first")
+      this.$input = this.$field.find("input:first")
+      this.$field_list = this.$el.find("div.acf-field-list")
+      this.$clone = this.$el.find(".acf-field-object.acf-clone").eq(0)
+      this.o = acf.get_data(this.$el)
+    },
+    initialize: function() {
+      // field events
+      this.$field.on("click", ".edit-field", function(e) {
+        e.preventDefault()
+        self.edit_field($(this).closest("div.acf-field-object"))
+      })
 
-	acf.fields.childbuilderbuilder = acf.field.extend({
-		type: 'childbuilder',
-		$el: null,
-		$input: null,
-		$field_list: null,
-		$clone: null,
-		actions: {
-			'ready': 'initialize',
-			'append': 'initialize',
-			'show': 'show'
-		},
-		events: {
-			'click .acf-childbuilder-add-row': 'add',
-			'click .acf-childbuilder-remove-row': 'remove',
-		},
-		focus: function () {
-			
-			this.$el = this.$field.find('.acf-childbuilder:first');
-			this.$input = this.$field.find('input:first');
-			this.$field_list = this.$el.find('div.acf-field-list');
-			this.$clone = this.$el.find('.acf-field-object.acf-clone').eq(0);
-			this.o = acf.get_data(this.$el);
+      this.$field.on("click", ".delete-field", function(e) {
+        e.preventDefault()
+        self.remove($(this).closest("div.acf-field-object"))
+      })
 
-		},
-		initialize: function () {
-			// field events
-			this.$field.on('click', '.edit-field', function (e) {
-				e.preventDefault();
-				self.edit_field( $(this).closest('div.acf-field-object') );
-			});
-			
-			this.$field.on('click', '.delete-field', function (e) {
-				e.preventDefault();
-				self.remove( $(this).closest('div.acf-field-object') );
-			});
-			
-			this.$field.on('keyup', 'div input[name$="[post_title]"]', function( e ){
-				
-				self.update_child_title_label( $(this) );
-				
-			});
-			
+      this.$field.on("keyup", 'div input[name$="[post_title]"]', function(e) {
+        self.update_child_title_label($(this))
+      })
 
-			// CSS fix
-			/*
+      // CSS fix
+      /*
 			 this.$tbody.on('mouseenter', 'tr.acf-row', function( e ){
 			 
 			 // vars
@@ -60,330 +54,269 @@
 			 });
 			 */
 
-			// sortable
-			if (this.o.max != 1) {
-
-				// reference
-				var self = this, $field_list = this.$field_list, $field = this.$field;
-
-
-				//this.$el.one('mouseenter', 'td.order', function( e ){
-
-				$field_list.unbind('sortable').sortable({
-					handle: '.acf-icon',
-					forceHelperSize: true,
-					forcePlaceholderSize: true,
-					scroll: true,
-					start: function (event, ui) {
-
-						// focus
-						self.doFocus($field);
-
-						acf.do_action('sortstart', ui.item, ui.placeholder);
-
-					},
-					stop: function (event, ui) {
-
-						// render
-						self.render();
-
-						acf.do_action('sortstop', ui.item, ui.placeholder);
-
-					},
-					update: function (event, ui) {
-
-						// trigger change
-						self.$input.trigger('change');
-
-					}
-
-				});
-
-				//});
-
-			}
-
-
-			// set column widths
-			// no longer needed due to refresh action in acf.pro model
-			//acf.pro.render_table( this.$el.children('table') );
-
-
-			// disable clone inputs
-			this.$clone.find('[name]').attr('disabled', 'disabled');
-
-
-			// render
-			this.render();
-
-		},
-		show: function () {
-
-			this.$el.find('.acf-field:visible').each(function () {
-
-				acf.do_action('show_field', $(this));
-
-			});
-
-		},
-		count: function () {
-
-			return this.$field_list.length - 1;
-
-		},
-		render: function () {
-
-			// loop over fields
-			this.$field_list.children().each(function (i) {
-				console.log(i + 1);
-				// update meta
-				//self.update_field_meta( $(this), 'menu_order', i );
-
-
-				// update icon number
-				$(this).children('.handle').find('.acf-icon').html(i + 1);
-			});
-
-
-			// empty?
-			if (this.count() == 0) {
-
-				this.$el.addClass('empty');
-
-			} else {
-
-				this.$el.removeClass('empty');
-
-			}
-
-
-			// row limit reached
-			if (this.o.max > 0 && this.count() >= this.o.max) {
-
-				this.$el.addClass('disabled');
-				this.$el.find('> .acf-hl .acf-button').addClass('disabled');
-
-			} else {
-
-				this.$el.removeClass('disabled');
-				this.$el.find('> .acf-hl .acf-button').removeClass('disabled');
-
-			}
-
-		},
-		add: function (e) {
-			// clone tr
-			
-			// validate
-			if (this.o.max > 0 && this.count() >= this.o.max) {
-
-				alert(acf._e('childbuilder', 'max').replace('{max}', this.o.max));
-				return false;
-
-			}
-			
-			
-			// create and add the new field
-			var new_id = acf.get_uniqid();
-			var html = this.$clone.outerHTML();
-			
-
-			// replace acfcloneindex
-			var html = html.replace(/(="[\w-\[\]]+?)(acfcloneindex)/g, '$1' + new_id);
-			var $html = $(html);
-
-
-			// remove clone class
-			$html.removeClass('acf-clone');
-			
-			// enable inputs
-			$html.find('[name]').removeAttr('disabled');
-			
-			// show
-			$html.show();
-			this.$clone.before($html);
-
-
-			// trigger mouseenter on parent childbuilder to work out css margin on add-row button
-			//this.$field.parents('.acf-row').trigger('mouseenter');
-
-
-			// update order
-			this.render();
-			this.open_field( $html.first('div.acf-field-object') );
-
-			// validation
-			//acf.validation.remove_error(this.$field);
-
-
-			// setup fields
-			acf.do_action('append', $html);
-			
-
-			// return
-			return $html;
-		},
-		remove : function( $el ){
-			// validate
-			if (this.count() <= this.o.min) {
-				//TODO:  Add in min checking
-				//alert(acf._e('childbuilder', 'min').replace('{min}', this.o.min));
-				//return false;
-			}
-			
-			// reference
-			var self = this;
-			
-			// vars
-			var $field_list	= $el.closest('.acf-field-list');
-			
-			// set layout
-			$el.css({
-				height		: $el.height(),
-				width		: $el.width(),
-				position	: 'absolute'
-			});
-			
-			
-			// wrap field
-			$el.wrap( '<div class="temp-field-wrap" style="height:' + $el.height() + 'px"></div>' );
-			
-			
-			// fade $el
-			$el.animate({ opacity : 0 }, 250);
-			
-			
-			// close field
-			var end_height = 0,
-			$show = false;
-			
-			
-			if( $field_list.children('.acf-field-object').length == 1 ) {
-				//TODO:  Add in no children message. 
-				//$show = $field_list.children('.no-fields-message');
-				//end_height = $show.outerHeight();
-			}
-			
-			$el.parent('.temp-field-wrap').animate({ height : end_height }, 250, function(){
-				
-				// show another element
-				if( $show ) {
-				
-					$show.show();
-					
-				}
-				
-				
-				// action for 3rd party customization 
-				acf.do_action('remove', $(this));
-				
-				
-				// remove $el
-				$(this).remove();
-				
-				
-				// render fields becuase they have changed
-				self.render();
-				
-			});
-		},
-		/*
-		 *  edit_field
-		 *
-		 *  This function is triggered when clicking on a field. It will open / close a fields settings
-		 *
-		 *  @type	function
-		 *  @date	8/04/2014
-		 *  @since	5.0.0
-		 *
-		 *  @param	$el
-		 *  @return	n/a
-		 */
-
-		edit_field: function ($el) {
-
-			if ($el.hasClass('open')) {
-
-				this.close_field($el);
-
-			} else {
-
-				this.open_field($el);
-
-			}
-	},
-		/*
-		 *  open_field
-		 *
-		 *  This function will open a fields settings
-		 *
-		 *  @type	function
-		 *  @date	8/04/2014
-		 *  @since	5.0.0
-		 *
-		 *  @param	$el
-		 *  @return	n/a
-		 */
-
-		open_field: function ($el) {
-
-			// bail early if already open
-			if ($el.hasClass('open')) {
-
-				return false;
-
-			}
-
-
-			// add class
-			$el.addClass('open');
-
-
-			// action for 3rd party customization
-			//acf.do_action('open_field', $el);
-
-
-			// animate toggle
-			$el.children('.settings').animate({'height': 'toggle'}, 250);
-	},
-		/*
-		 *  close_field
-		 *
-		 *  This function will open a fields settings
-		 *
-		 *  @type	function
-		 *  @date	8/04/2014
-		 *  @since	5.0.0
-		 *
-		 *  @param	$el
-		 *  @return	n/a
-		 */
-
-		close_field: function ($el) {
-
-			// bail early if already closed
-			if (!$el.hasClass('open')) {
-
-				return false;
-
-			}
-
-
-			// remove class
-			$el.removeClass('open');
-
-
-			// action for 3rd party customization
-			//acf.do_action('close_field', $el);
-
-
-			// animate toggle
-			$el.children('.settings').animate({'height': 'toggle'}, 250);		
-		},
-		update_child_title_label : function($input) {
-			var $el =  $input.closest('div.acf-field-object');
-			$el.find('.handle .li-field-label strong a').text( $input.val() );
-		},
-	});
-
-})(jQuery);
+      // sortable
+      if (this.o.max != 1) {
+        // reference
+        var self = this,
+          $field_list = this.$field_list,
+          $field = this.$field
+
+        //this.$el.one('mouseenter', 'td.order', function( e ){
+
+        $field_list.unbind("sortable").sortable({
+          handle: ".acf-icon",
+          forceHelperSize: true,
+          forcePlaceholderSize: true,
+          scroll: true,
+          start: function(event, ui) {
+            // focus
+            self.doFocus($field)
+
+            acf.do_action("sortstart", ui.item, ui.placeholder)
+          },
+          stop: function(event, ui) {
+            // render
+            self.render()
+
+            acf.do_action("sortstop", ui.item, ui.placeholder)
+          },
+          update: function(event, ui) {
+            // trigger change
+            self.$input.trigger("change")
+          }
+        })
+
+        //});
+      }
+
+      // set column widths
+      // no longer needed due to refresh action in acf.pro model
+      //acf.pro.render_table( this.$el.children('table') );
+
+      // disable clone inputs
+      this.$clone.find("[name]").attr("disabled", "disabled")
+
+      // render
+      this.render()
+    },
+    show: function() {
+      this.$el.find(".acf-field:visible").each(function() {
+        acf.do_action("show_field", $(this))
+      })
+    },
+    count: function() {
+      return this.$field_list[0].children.length - 1
+    },
+    render: function() {
+      // loop over fields
+      this.$field_list.children().each(function(i) {
+        // update meta
+        //self.update_field_meta( $(this), 'menu_order', i );
+
+        // update icon number
+        $(this)
+          .children(".handle")
+          .find(".acf-icon")
+          .html(i + 1)
+      })
+
+      // empty?
+      if (this.count() == 0) {
+        this.$el.addClass("empty")
+      } else {
+        this.$el.removeClass("empty")
+      }
+
+      // row limit reached
+      if (this.o.max > 0 && this.count() >= this.o.max) {
+        this.$el.addClass("disabled")
+        this.$el.find("> .acf-hl .acf-button").addClass("disabled")
+      } else {
+        this.$el.removeClass("disabled")
+        this.$el.find("> .acf-hl .acf-button").removeClass("disabled")
+      }
+    },
+    add: function(e) {
+      // clone tr
+
+      // validate
+      if (this.o.max > 0 && this.count() >= this.o.max) {
+        alert(acf._e("childbuilder", "max").replace("{max}", this.o.max))
+        return false
+      }
+
+      // create and add the new field
+      var new_id = acf.get_uniqid()
+      var html = this.$clone.outerHTML()
+
+      // replace acfcloneindex
+      var html = html.replace(/(="[\w-\[\]]+?)(acfcloneindex)/g, "$1" + new_id)
+      var $html = $(html)
+
+      // remove clone class
+      $html.removeClass("acf-clone")
+
+      // enable inputs
+      $html.find("[name]").removeAttr("disabled")
+
+      // show
+      $html.show()
+      this.$clone.before($html)
+
+      // trigger mouseenter on parent childbuilder to work out css margin on add-row button
+      //this.$field.parents('.acf-row').trigger('mouseenter');
+
+      // update order
+      this.render()
+      this.open_field($html.first("div.acf-field-object"))
+
+      // validation
+      //acf.validation.remove_error(this.$field);
+
+      // setup fields
+      acf.do_action("append", $html)
+
+      // return
+      return $html
+    },
+    remove: function($el) {
+      // validate
+      if (this.count() <= this.o.min) {
+        //TODO:  Add in min checking
+        //alert(acf._e('childbuilder', 'min').replace('{min}', this.o.min));
+        //return false;
+      }
+
+      // reference
+      var self = this
+
+      // vars
+      var $field_list = $el.closest(".acf-field-list")
+
+      // set layout
+      $el.css({
+        height: $el.height(),
+        width: $el.width(),
+        position: "absolute"
+      })
+
+      // wrap field
+      $el.wrap(
+        '<div class="temp-field-wrap" style="height:' +
+          $el.height() +
+          'px"></div>'
+      )
+
+      // fade $el
+      $el.animate({ opacity: 0 }, 250)
+
+      // close field
+      var end_height = 0,
+        $show = false
+
+      if ($field_list.children(".acf-field-object").length == 1) {
+        //TODO:  Add in no children message.
+        //$show = $field_list.children('.no-fields-message');
+        //end_height = $show.outerHeight();
+      }
+
+      $el
+        .parent(".temp-field-wrap")
+        .animate({ height: end_height }, 250, function() {
+          // show another element
+          if ($show) {
+            $show.show()
+          }
+
+          // action for 3rd party customization
+          acf.do_action("remove", $(this))
+
+          // remove $el
+          $(this).remove()
+
+          // render fields becuase they have changed
+          self.render()
+        })
+    },
+    /*
+     *  edit_field
+     *
+     *  This function is triggered when clicking on a field. It will open / close a fields settings
+     *
+     *  @type	function
+     *  @date	8/04/2014
+     *  @since	5.0.0
+     *
+     *  @param	$el
+     *  @return	n/a
+     */
+
+    edit_field: function($el) {
+      if ($el.hasClass("open")) {
+        this.close_field($el)
+      } else {
+        this.open_field($el)
+      }
+    },
+    /*
+     *  open_field
+     *
+     *  This function will open a fields settings
+     *
+     *  @type	function
+     *  @date	8/04/2014
+     *  @since	5.0.0
+     *
+     *  @param	$el
+     *  @return	n/a
+     */
+
+    open_field: function($el) {
+      // bail early if already open
+      if ($el.hasClass("open")) {
+        return false
+      }
+
+      // add class
+      $el.addClass("open")
+
+      // action for 3rd party customization
+      //acf.do_action('open_field', $el);
+
+      // animate toggle
+      $el.children(".settings").animate({ height: "toggle" }, 250)
+    },
+    /*
+     *  close_field
+     *
+     *  This function will open a fields settings
+     *
+     *  @type	function
+     *  @date	8/04/2014
+     *  @since	5.0.0
+     *
+     *  @param	$el
+     *  @return	n/a
+     */
+
+    close_field: function($el) {
+      // bail early if already closed
+      if (!$el.hasClass("open")) {
+        return false
+      }
+
+      // remove class
+      $el.removeClass("open")
+
+      // action for 3rd party customization
+      //acf.do_action('close_field', $el);
+
+      // animate toggle
+      $el.children(".settings").animate({ height: "toggle" }, 250)
+    },
+    update_child_title_label: function($input) {
+      var $el = $input.closest("div.acf-field-object")
+      $el.find(".handle .li-field-label strong a").text($input.val())
+    }
+  })
+})(jQuery)

--- a/assets/js/acf-child-post-field.js
+++ b/assets/js/acf-child-post-field.js
@@ -22,6 +22,8 @@
       this.o = acf.get_data(this.$el)
     },
     initialize: function() {
+      var self = this
+
       // field events
       this.$field.on("click", ".edit-field", function(e) {
         e.preventDefault()


### PR DESCRIPTION
The update_value function has been updated so that redundant children (those removed from the repeater) are handled and removed properly. Previously there were multiple issues with handling of post deletion and db update when repeater rows were removed. For example, adding two children then removing just the first would cause the second post to be deleted while retaining its record in the database.

Redundant meta data wasn't being deleted because acf_delete_value expects a field and a key was being passed. Updated to instead use two calls to acf_delete_metadata - one to delete the actual value and one to delete the hidden reference.